### PR TITLE
Do not animate icon when page is not visible. Fixes #18.

### DIFF
--- a/favico.js
+++ b/favico.js
@@ -481,6 +481,14 @@
         }
 
         /**
+         * Cross-browser page visibility shim
+         * http://stackoverflow.com/questions/12536562/detect-whether-a-window-is-visible
+         */
+        function isPageHidden(){
+            return document.hidden || document.msHidden || document.webkitHidden || document.mozHidden;
+        }
+
+        /**
          * @namespace animation
          */
         var animation = {};
@@ -709,7 +717,7 @@
          * @param {Object} step Optional step number (frame bumber)
          */
         animation.run = function(opt, cb, revert, step) {
-            var animationType = animation.types[_opt.animation];
+            var animationType = animation.types[isPageHidden() ? 'none' : _opt.animation];
             if (revert === true) {
                 step = ( typeof step !== 'undefined') ? step : animationType.length - 1;
             } else {


### PR DESCRIPTION
isPageHidden will always return undefined for browsers that do not support page visibility, but we shouldn't have to worry about those browsers since we don't support them anyway.
