### PR TITLE
use feature detection for browsers, make _browser.supported public

### DIFF
--- a/favico.js
+++ b/favico.js
@@ -37,12 +37,13 @@
         var _opt, _orig, _h, _w, _canvas, _context, _img, _ready, _lastBadge, _running, _readyCb, _stop, _browser, _animTimeout, _drawTimeout;
 
         _browser = {};
-        _browser.ff = (/firefox/i.test(navigator.userAgent.toLowerCase()));
-        _browser.chrome = (/chrome/i.test(navigator.userAgent.toLowerCase()));
-        _browser.opera = (/opera/i.test(navigator.userAgent.toLowerCase()));
-        _browser.ie = (/msie/i.test(navigator.userAgent.toLowerCase())) || (/trident/i.test(navigator.userAgent.toLowerCase()));
+        _browser.ff = typeof InstallTrigger != 'undefined';
+        _browser.chrome = !!window.chrome;
+        _browser.opera = !!window.opera || navigator.userAgent.indexOf('Opera') >= 0;
+        _browser.ie = /*@cc_on!@*/ false;
+        _browser.safari = Object.prototype.toString.call(window.HTMLElement).indexOf('Constructor') > 0;
         _browser.supported = (_browser.chrome || _browser.ff || _browser.opera);
-
+    
         var _queue = [];
         _readyCb = function() {
         };
@@ -810,7 +811,10 @@
             video : video,
             image : image,
             webcam : webcam,
-            reset : icon.reset
+            reset : icon.reset,
+            browser: {
+               supported: _browser.supported
+            }
         };
     });
 
@@ -830,3 +834,5 @@
     }
 
 })();
+
+


### PR DESCRIPTION
Changed the browser detection to use feature detection over regexs.  Also added in a detection for safari for later support.

Also made the _browser.supported variable public because on my current project, we were needing to handle two separate types of favicons depending on the browser.  As this lib already had it's own array for supported browsers, I thought it'd be more useful to ask the lib what it supports rather than having my own duplicate browser detection code.  `browser.supported` was the current key I'm going with, although I'm not married to that if you would rather a different structure.
