### PR TITLE
reset _running state when reset icon; fixes #49

### DIFF
--- a/favico.js
+++ b/favico.js
@@ -142,6 +142,7 @@
 			}
 			_queue = [];
 			_lastBadge = false;
+			_running = false;
 			_context.clearRect(0, 0, _w, _h);
 			_context.drawImage(_img, 0, 0, _w, _h);
 			//_stop=true;


### PR DESCRIPTION
Trying to fix https://github.com/ejci/favico.js/issues/49

I changed `_running = false` into `icon.reset` method to make it neat.
