### PR TITLE
add options.element to forward a dom element to favico.js

### DIFF
--- a/favico.js
+++ b/favico.js
@@ -465,7 +465,9 @@
 				}
 				return false;
 			};
-			if (_opt.elementId) {
+			if (_opt.element) {
+				elm = _opt.element;
+			} else if (_opt.elementId) {
 				//if img element identified by elementId
 				elm = document.getElementById(_opt.elementId);
 				elm.setAttribute('href', elm.getAttribute('src'));
@@ -488,7 +490,9 @@
 		};
 		link.setIcon = function(canvas) {
 			var url = canvas.toDataURL('image/png');
-			if (_opt.elementId) {
+			if (_opt.element) {
+				_opt.element.setAttribute('src', url);
+			} else if (_opt.elementId) {
 				//if is attached to element (image)
 				document.getElementById(_opt.elementId).setAttribute('src', url);
 			} else {


### PR DESCRIPTION
Hey, I have the scenario, that I have several favicons in the head like this:

```
<link rel="icon" type="image/png" href="/favicon-192x192.png" sizes="192x192">
<link rel="icon" type="image/png" href="/favicon-160x160.png" sizes="160x160">
<link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96">
<link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
<link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
```

With a single instance of Favico.js only one of the favicons was manipulated.
Using the "elementId" Option didn't worked too, because it overwrites the href with the empty src. This results then in a exception.

So I ended up with adding the option to pass a dom element directly to favico, which allowed me then to hack around the issue. This is the way how I use now favicon in my code.

``` javascript
jQuery('head > link[rel="icon"]').each(function() {
    var newFavicon = new Favico({
        bgColor : '#c4662b',
        animation : 'popFade',
        element : this
        });

    faviconJS.push(newFavicon);
});


faviconJS.forEach(function(faviconJS) {
    faviconJS.badge(currentNotificationValue);
});
```

I was thinking about modifying favico, so the library itself can handle this multi icons in a proper way, but didn't wanted to make a so big change without knowing that there is interest.
