### PR TITLE
Added setter support. Fixes #54

### DIFF
--- a/favico.js
+++ b/favico.js
@@ -496,6 +496,9 @@
 			} else if (_opt.elementId) {
 				//if is attached to element (image)
 				document.getElementById(_opt.elementId).setAttribute('src', url);
+			} else if (_opt.setter) {
+				//if using custom exporter
+				_opt.setter(url);
 			} else {
 				//if is attached to fav icon
 				if (_browser.ff || _browser.opera) {


### PR DESCRIPTION
As discussed in #54 it would be nice to have support for an option that allows setting any item via a `function` (e.g. tray icon). In this PR:

- Added `setter` support which takes a function of signature `function (url) {`

For testing, I used the `console` as a demo:

![favico in the console](https://cloud.githubusercontent.com/assets/902488/5594180/fd336588-9204-11e4-95fd-0cd246f7672d.png)

If you want to try it yourself, see https://github.com/twolfson/favico.js/blob/62eb5957938da558464e85e13be39b371a72d80a/example-simple/index.html

```js
var favicon = new Favico({
  animation : 'popFade',
  setter : function (url) {
    // http://jmperezperez.com/console-log-favicon/
    var css = "background-image: url('" + url + "');" +
              "background-repeat: no-repeat;" +
              "display: block;" +
              "background-size: 13px 13px;" +
              "padding-left: 13px;" +
              "margin-left: 5px;";
    console.log('%c   favico.js', css);
  }
});
```