### PR TITLE
add default npm registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
 		"type": "git",
 		"url": "git://github.com/ejci/favico.js.git"
 	},
+	"publishConfig": {
+		"registry": "http://registry.npmjs.org/"
+	},
 	"keywords": ["favicon", "badge"],
 	"author": "Miroslav Magda <magda.miroslav@gmail.com>",
 	"license": "MIT",


### PR DESCRIPTION
this ensures that the repo is set up to publish to the default NPM registry (http://registry.npmjs.org/).

it's useful for people whose systems are set up to use a different default NPM registry.