### PR TITLE
Bug fix to works with CORS.

### DIFF
--- a/favico.js
+++ b/favico.js
@@ -97,6 +97,7 @@
 			//create temp image
 			_img = document.createElement('img');
 			if (_orig.hasAttribute('href')) {
+				_img.setAttribute('crossOrigin', 'anonymous');
 				_img.setAttribute('src', _orig.getAttribute('href'));
 				//get width/height
 				_img.onload = function() {
@@ -345,6 +346,7 @@
 					var h = imageElement.height;
 					var newImg = document.createElement('img');
 					var ratio = (w / _w < h / _h) ? (w / _w) : (h / _h);
+					newImg.setAttribute('crossOrigin', 'anonymous');
 					newImg.setAttribute('src', imageElement.getAttribute('src'));
 					newImg.height = (h / ratio);
 					newImg.width = (w / ratio);


### PR DESCRIPTION
Apparently canvas gets into a "tainted" mode if you pull from an image that is a different domain than the page your on. Even if the `Access-Control-Allow-Origin` header is set to allow it. You have to set a `crossorigin` attribute on the image that you pull into canvas from. More info here: https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image