### PR TITLE
#67 Use Error constructor to keep message and stack

### DIFF
--- a/favico.js
+++ b/favico.js
@@ -325,14 +325,14 @@
 						});
 						_queue.push(q);
 						if (_queue.length > 100) {
-							throw 'Too many badges requests in queue.';
+							throw new Error('Too many badges requests in queue.');
 						}
 						icon.start();
 					} else {
 						icon.reset();
 					}
 				} catch(e) {
-					throw 'Error setting badge. Message: ' + e.message;
+					throw new Error('Error setting badge. Message: ' + e.message);
 				}
 			};
 			if (_ready) {
@@ -358,7 +358,7 @@
 					_context.drawImage(newImg, 0, 0, _w, _h);
 					link.setIcon(_canvas);
 				} catch(e) {
-					throw 'Error setting image. Message: ' + e.message;
+					throw new Error('Error setting image. Message: ' + e.message);
 				}
 			};
 			if (_ready) {
@@ -385,7 +385,7 @@
 					}, false);
 
 				} catch(e) {
-					throw 'Error setting video. Message: ' + e.message;
+					throw new Error('Error setting video. Message: ' + e.message);
 				}
 			};
 			if (_ready) {
@@ -427,7 +427,7 @@
 						}, function() {
 						});
 					} catch(e) {
-						throw 'Error setting webcam. Message: ' + e.message;
+						throw new Error('Error setting webcam. Message: ' + e.message);
 					}
 				};
 				if (_ready) {
@@ -846,4 +846,3 @@
 	}
 
 })();
-


### PR DESCRIPTION
This PR aims to provider more useful information for debugging.

`new Error()` will make `message` and `stack` available in other code scopes.

![untitled js 2015-05-26 13-26-44](https://cloud.githubusercontent.com/assets/189559/7805768/e87b03ea-03aa-11e5-85b6-3160e8b58bbd.png)


