### PR TITLE
Call setTimeout with function expression.

### DIFF
--- a/favico.js
+++ b/favico.js
@@ -451,7 +451,9 @@
 			} catch(e) {
 
 			}
-			_drawTimeout = setTimeout(drawVideo, animation.duration, video);
+			_drawTimeout = setTimeout(function() {
+				drawVideo(video);
+			}, animation.duration);
 			link.setIcon(_canvas);
 		}
 


### PR DESCRIPTION
In order to prevent vulnerabilities, the `setTimeout` and `setInterval` functions should be called only with function expressions as their first argument.