### PR TITLE
Allow to set favicon from an image src

### DIFF
--- a/favico.js
+++ b/favico.js
@@ -373,6 +373,17 @@
 			}
 		};
 		/**
+		 * Set the icon from a source url. Won't work with badges.
+		 */
+		var rawImageSrc = function (url) {
+			_readyCb = function() {
+				link.setIconSrc(url);
+			};
+			if (_ready) {
+				_readyCb();
+			}
+		};
+		/**
 		 * Set video as icon
 		 */
 		var video = function (videoElement) {
@@ -500,6 +511,9 @@
 		};
 		link.setIcon = function (canvas) {
 			var url = canvas.toDataURL('image/png');
+			link.setIconSrc(url);
+		};
+		link.setIconSrc = function (url) {
 			if (_opt.dataUrl) {
 				//if using custom exporter
 				_opt.dataUrl(url);
@@ -834,6 +848,7 @@
 			badge: badge,
 			video: video,
 			image: image,
+			rawImageSrc: rawImageSrc,
 			webcam: webcam,
 			reset: icon.reset,
 			browser: {


### PR DESCRIPTION
This allows set a raw favicon from an image source directly, bypassing any CORS problems with cross-origin images (https://github.com/ejci/favico.js/issues/43). Badges won't work with the new image however, setting a badge will revert back to the previous icon
